### PR TITLE
Add Dependabot dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "security"
+
+  - package-ecosystem: "pip"
+    directory: "/extra/dashboard"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:30"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "security"


### PR DESCRIPTION
## Summary
- add `.github/dependabot.yml` for automated Python dependency updates
- monitor the root package dependencies from `setup.py`
- monitor dashboard dependencies from `extra/dashboard/requirements.txt`

## Bounty
Refs Scottcjn/rustchain-bounties#1613. The repo did not have an existing Dependabot or Renovate configuration, and duplicate PR checks found no open dependency-update setup PRs before this work.

## Validation
- `ruby -e 'require "yaml"; data = YAML.load_file(".github/dependabot.yml"); abort "bad version" unless data["version"] == 2; abort "bad updates" unless data["updates"].is_a?(Array) && data["updates"].length == 2; puts "dependabot yaml ok"'`\n- `git diff --check`