### PR TITLE
docs: fix RustChain branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ For more help, open an issue with your error message and system details.
 
 **[Elyan Labs](https://github.com/Scottcjn)** · 1,882 commits · 97 repos · 1,334 stars · $0 raised
 
-[⭐ Star Rustchain](https://github.com/Scottcjn/Rustchain) · [📊 Q1 2026 Traction Report](https://github.com/Scottcjn/Rustchain/blob/main/docs/DEVELOPER_TRACTION_Q1_2026.md) · [Follow @Scottcjn](https://github.com/Scottcjn)
+[⭐ Star RustChain](https://github.com/Scottcjn/Rustchain) · [📊 Q1 2026 Traction Report](https://github.com/Scottcjn/Rustchain/blob/main/docs/DEVELOPER_TRACTION_Q1_2026.md) · [Follow @Scottcjn](https://github.com/Scottcjn)
 
 </div>
 


### PR DESCRIPTION
## Summary
- Fix README footer link text from Star Rustchain to Star RustChain
- Preserve the existing Scottcjn/Rustchain repository URL

## Validation
- Confirmed only open PR #12 is unrelated Dependabot automation
- Confirmed no #2178/exo-cuda branding duplicate comment before worker-010 claim
- Ran git diff --cached --check
- Confirmed README now contains Star RustChain and no Star Rustchain footer text

Bounty reference: Scottcjn/rustchain-bounties#2178