### PR TITLE
[codex] Fix ChatGPT API example grammar

### DIFF
--- a/examples/chatgpt_api.sh
+++ b/examples/chatgpt_api.sh
@@ -1,4 +1,4 @@
-# exo provides an API that aims to be a drop-in replacements for the ChatGPT-API.
+# exo provides an API that aims to be a drop-in replacement for the ChatGPT-API.
 # This example shows how you can use the API first without streaming and second with streaming.
 # This works the same in a single-node set up and in a multi-node setup.
 # You need to start exo before running this by running `python3 main.py`.


### PR DESCRIPTION
## Summary\n- Fix the introductory comment in examples/chatgpt_api.sh from "a drop-in replacements" to "a drop-in replacement".\n\n## Validation\n- git diff --check\n- codespell examples/chatgpt_api.sh\n- rg stale/corrected phrase check for the example comment\n\nBounty: Scottcjn/rustchain-bounties#2178