### PR TITLE
Fix tokenizer comment typo

### DIFF
--- a/test/test_tokenizers.py
+++ b/test/test_tokenizers.py
@@ -35,7 +35,7 @@ models = list(set(models))
 
 verbose = os.environ.get("VERBOSE", "0").lower() == "1"
 for m in models:
-    # TODO: figure out why use_fast=False is giving inconsistent behaviour (no spaces decoding invididual tokens) for Mistral-Large-Instruct-2407-4bit
+    # TODO: figure out why use_fast=False is giving inconsistent behaviour (no spaces decoding individual tokens) for Mistral-Large-Instruct-2407-4bit
     # test_tokenizer(m, AutoProcessor.from_pretrained(m, use_fast=False), verbose)
     if m not in ["mlx-community/DeepSeek-R1-4bit", "mlx-community/DeepSeek-R1-3bit", "mlx-community/DeepSeek-V3-4bit", "mlx-community/DeepSeek-V3-3bit"]:
       test_tokenizer(m, AutoProcessor.from_pretrained(m, use_fast=True, trust_remote_code=True), verbose)


### PR DESCRIPTION
## Summary
- fix a typo in the tokenizer test TODO comment: `invididual` -> `individual`

## Validation
- `git diff --check`
- `codespell test/test_tokenizers.py`
- `rg -n "invididual|individual tokens" test/test_tokenizers.py`