### PR TITLE
fix(cuda): round compute-cap fraction instead of truncating (RTX 30-series -> sm_85)

### DIFF
--- a/cuda_arch_setup.py
+++ b/cuda_arch_setup.py
@@ -57,7 +57,7 @@ def detect_cuda_gpus() -> List[Dict]:
                     
                     # Convert compute capability (e.g., 7.5) to (7, 5)
                     major = int(compute_cap)
-                    minor = int((compute_cap - major) * 10)
+                    minor = round((compute_cap - major) * 10)
                     
                     gpus.append({
                         'name': name,

--- a/test/test_cuda_arch_setup.py
+++ b/test/test_cuda_arch_setup.py
@@ -1,8 +1,33 @@
 import os
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
-from cuda_arch_setup import generate_cudaarchs, get_arch_string, set_environment_variables
+from cuda_arch_setup import (
+    detect_cuda_gpus,
+    generate_cudaarchs,
+    get_arch_string,
+    set_environment_variables,
+)
+
+
+class TestDetectCudaGpus(unittest.TestCase):
+  def _run_with_nvidia_smi(self, csv_line):
+    proc = MagicMock(returncode=0, stdout=csv_line + "\n")
+    with patch("cuda_arch_setup.subprocess.run", return_value=proc):
+      return detect_cuda_gpus()
+
+  def test_compute_cap_fraction_is_rounded_not_truncated(self):
+    # Float(8.6) - 8 == 0.5999999... ; int() would floor to minor=5 (sm_85,
+    # a non-existent arch). Real RTX 3090 is sm_86.
+    gpu = self._run_with_nvidia_smi("NVIDIA GeForce RTX 3090, 8.6, 550.00, 24576")[0]
+    self.assertEqual((gpu["major"], gpu["minor"]), (8, 6))
+    self.assertEqual(get_arch_string((gpu["major"], gpu["minor"])), "sm_86")
+
+  def test_pascal_and_jetson_caps_round_correctly(self):
+    g1080 = self._run_with_nvidia_smi("NVIDIA GeForce GTX 1080, 6.1, 550.00, 8192")[0]
+    self.assertEqual((g1080["major"], g1080["minor"]), (6, 1))
+    orin = self._run_with_nvidia_smi("Jetson AGX Orin, 8.7, 540.00, 32768")[0]
+    self.assertEqual((orin["major"], orin["minor"]), (8, 7))
 
 
 class TestCudaArchSetup(unittest.TestCase):


### PR DESCRIPTION
## Problem
`detect_cuda_gpus()` converts nvidia-smi's `compute_cap` (a float like `8.6`) to `(major, minor)` with:
```python
minor = int((compute_cap - major) * 10)
```
Because `8.6`, `6.1`, `8.7`, `5.3` aren't exactly representable in float64, `(8.6 - 8) * 10 == 5.9999999999999964`, and `int()` **floors** it to `5`. So:

| GPU | compute_cap | parsed | arch emitted |
|-----|-------------|--------|--------------|
| RTX 3060/3080/3090 | 8.6 | (8,**5**) | `sm_85` (does not exist) → dropped, generic fallback |
| GTX 1060/1070/1080 | 6.1 | (6,**0**) | `sm_60` → builds Pascal-P100 code for a GP104 card |
| Jetson AGX Orin | 8.7 | (8,**6**) | `sm_86` (wrong card) |

GTX 1650 (cc 7.5) happens to be exactly representable, which is why the bug wasn't obvious. For the 30-series and 10-series this yields `cudaErrorInvalidDeviceFunction` at runtime — the exact failure the module's docstring says it prevents. `get_arch_string()` / `generate_cudaarchs()` are fed these wrong minors on the live `detect_cuda_gpus` → `display_gpu_info`/`set_environment_variables`/`--json` path.

## Fix
Use `round()` instead of `int()`. Verified correct for every real compute cap (5.0–9.0).

## Test
Added `TestDetectCudaGpus` mocking `nvidia-smi` for RTX 3090 (8.6), GTX 1080 (6.1) and Jetson Orin (8.7). Reverting the one-line fix makes both new tests fail; with the fix `test/test_cuda_arch_setup.py` is **7 passed**. The pre-existing tests hand-built gpu dicts with integer minors, so the parse arithmetic was uncovered.

RTC: `RTCd1554f0f35576faf01d386a6be1c947f560dd0b7`