### PR TITLE
interweave: fix i8/i4 quantize round-trip corrupting values >= half range

### DIFF
--- a/exo/interweave/tensor_format.py
+++ b/exo/interweave/tensor_format.py
@@ -194,18 +194,28 @@ class UniversalTensor:
 
     def to_numpy(self) -> np.ndarray:
         """Convert to numpy array"""
+        # Quantized i8 stores unsigned zero-point levels (0..255, see
+        # convert_dtype). Reading them back through the signed int8 view
+        # would wrap anything >= 128 to a negative number and corrupt every
+        # dequantization that depends on it.
+        if self.dtype == DType.I8 and self.scale is not None:
+            arr = np.frombuffer(self.data, dtype=np.uint8)
+            return arr.reshape(self.shape)
+
         np_dtype = self.dtype.to_numpy()
         arr = np.frombuffer(self.data, dtype=np_dtype)
 
         # Handle packed i4
         if self.dtype == DType.I4:
-            # Unpack 4-bit values
-            unpacked = np.zeros(self.numel, dtype=np.int8)
-            for i, byte in enumerate(arr):
+            # Unpack 4-bit values. Nibbles hold unsigned zero-point levels
+            # (0..15, see convert_dtype) - matching how they were packed.
+            raw = arr.view(np.uint8)
+            unpacked = np.zeros(self.numel, dtype=np.uint8)
+            for i, byte in enumerate(raw):
                 if i * 2 < self.numel:
-                    unpacked[i * 2] = (byte & 0x0F) - 8  # Signed 4-bit
+                    unpacked[i * 2] = byte & 0x0F
                 if i * 2 + 1 < self.numel:
-                    unpacked[i * 2 + 1] = ((byte >> 4) & 0x0F) - 8
+                    unpacked[i * 2 + 1] = (byte >> 4) & 0x0F
             arr = unpacked
 
         return arr.reshape(self.shape)
@@ -263,20 +273,31 @@ class UniversalTensor:
         # Handle quantization
         if target_dtype in (DType.I8, DType.I4) and self.dtype in (DType.F32, DType.F16, DType.BF16):
             # Quantize: compute scale and zero point
-            min_val, max_val = arr.min(), arr.max()
+            min_val, max_val = float(arr.min()), float(arr.max())
+            value_range = max_val - min_val
+            levels = 255.0 if target_dtype == DType.I8 else 15.0
+            if value_range == 0.0:
+                # Constant block (e.g. zero-padded KV slot): there's no
+                # dynamic range to spread across levels, so fall back to a
+                # safe unit scale instead of dividing by zero and poisoning
+                # the whole tensor with NaN.
+                scale = 1.0
+                zero_point = round(-min_val)
+            else:
+                scale = value_range / levels
+                zero_point = round(-min_val / scale)
+            # Levels are unsigned zero-point offsets (0..255 / 0..15), matching
+            # how to_numpy() unpacks them back out below.
+            quantized_levels = np.round(arr / scale + zero_point).clip(0, levels).astype(np.uint8)
+
             if target_dtype == DType.I8:
-                scale = (max_val - min_val) / 255.0
-                zero_point = int(-min_val / scale)
-                quantized = np.round(arr / scale + zero_point).astype(np.int8)
-            else:  # I4
-                scale = (max_val - min_val) / 15.0
-                zero_point = int(-min_val / scale)
-                quantized = np.round(arr / scale + zero_point).clip(0, 15).astype(np.int8)
-                # Pack into bytes
-                packed = np.zeros((quantized.size + 1) // 2, dtype=np.uint8)
-                for i in range(0, quantized.size, 2):
-                    low = quantized.flat[i] & 0x0F
-                    high = (quantized.flat[i + 1] & 0x0F) if i + 1 < quantized.size else 0
+                quantized = quantized_levels
+            else:  # I4: pack two unsigned nibbles per byte
+                flat = quantized_levels.flatten()
+                packed = np.zeros((flat.size + 1) // 2, dtype=np.uint8)
+                for i in range(0, flat.size, 2):
+                    low = flat[i] & 0x0F
+                    high = (flat[i + 1] & 0x0F) if i + 1 < flat.size else 0
                     packed[i // 2] = low | (high << 4)
                 quantized = packed
 

--- a/exo/interweave/test_tensor_format.py
+++ b/exo/interweave/test_tensor_format.py
@@ -1,0 +1,123 @@
+"""
+Regression tests for UniversalTensor int8/int4 quantization round-trip.
+
+convert_dtype() packs quantized levels as *unsigned* zero-point offsets
+(0..255 for i8, 0..15 for i4 nibbles). to_numpy() must unpack them the same
+way, otherwise any level >= 128 (i8) or >= 8 (i4) gets reinterpreted as a
+negative signed byte/nibble and the whole tensor comes back corrupted -
+exactly the kind of thing that silently wrecks a distributed KV-cache
+transfer without ever raising an exception.
+"""
+
+import numpy as np
+
+from exo.interweave.tensor_format import DType, UniversalTensor
+
+
+def _max_abs_err(orig: np.ndarray, recon: np.ndarray) -> float:
+    return float(np.max(np.abs(orig.astype(np.float64) - recon.astype(np.float64))))
+
+
+def test_i8_roundtrip_stays_within_one_quantization_step():
+    arr = np.linspace(-2.0, 2.0, 256).astype(np.float32)
+    tensor = UniversalTensor.from_numpy(arr)
+
+    quantized = tensor.convert_dtype(DType.I8)
+    recon = quantized.convert_dtype(DType.F32).to_numpy()
+
+    # Max quantization error for 255 levels over the value range should
+    # never exceed half a step. Before the fix, high-magnitude values that
+    # quantize to level >= 128 wrapped through signed int8 and blew this
+    # bound apart (observed error ~4.0 on a range of 4.0).
+    step = 4.0 / 255.0
+    assert _max_abs_err(arr, recon) <= step / 2 + 1e-4
+
+
+def test_i4_roundtrip_stays_within_one_quantization_step():
+    arr = np.linspace(-2.0, 2.0, 16).astype(np.float32)
+    tensor = UniversalTensor.from_numpy(arr)
+
+    quantized = tensor.convert_dtype(DType.I4)
+    recon = quantized.convert_dtype(DType.F32).to_numpy()
+
+    step = 4.0 / 15.0
+    assert _max_abs_err(arr, recon) <= step / 2 + 1e-4
+
+
+def test_i8_high_level_values_do_not_wrap_negative():
+    # Values near max_val quantize to levels close to 255, which is exactly
+    # the region that got corrupted by the signed int8 reinterpretation.
+    arr = np.array([-10.0, -5.0, 0.0, 5.0, 9.5, 10.0], dtype=np.float32)
+    tensor = UniversalTensor.from_numpy(arr)
+
+    quantized = tensor.convert_dtype(DType.I8)
+    raw_levels = quantized.to_numpy()
+    # Unsigned levels must never be reported as negative.
+    assert raw_levels.min() >= 0
+    assert raw_levels.max() <= 255
+
+    recon = quantized.convert_dtype(DType.F32).to_numpy()
+    step = 20.0 / 255.0
+    assert _max_abs_err(arr, recon) <= step / 2 + 1e-3
+
+
+def test_i4_high_nibble_values_do_not_wrap_negative():
+    arr = np.array([-10.0, -5.0, 0.0, 5.0, 9.0, 10.0], dtype=np.float32)
+    tensor = UniversalTensor.from_numpy(arr)
+
+    quantized = tensor.convert_dtype(DType.I4)
+    raw_levels = quantized.to_numpy()
+    assert raw_levels.min() >= 0
+    assert raw_levels.max() <= 15
+
+    recon = quantized.convert_dtype(DType.F32).to_numpy()
+    step = 20.0 / 15.0
+    assert _max_abs_err(arr, recon) <= step / 2 + 1e-3
+
+
+def test_i8_random_kv_cache_like_data_roundtrips():
+    rng = np.random.default_rng(0)
+    arr = (rng.standard_normal(4096).astype(np.float32) * 3.0)
+
+    tensor = UniversalTensor.from_numpy(arr)
+    quantized = tensor.convert_dtype(DType.I8)
+    recon = quantized.convert_dtype(DType.F32).to_numpy()
+
+    step = (float(arr.max()) - float(arr.min())) / 255.0
+    assert _max_abs_err(arr, recon) <= step / 2 + 1e-3
+
+
+def test_constant_tensor_quantization_does_not_produce_nan():
+    # A constant block (e.g. a zero-padded KV slot) has zero dynamic range,
+    # which used to divide by zero and poison the tensor with NaN.
+    arr = np.full(64, 5.37, dtype=np.float32)
+    tensor = UniversalTensor.from_numpy(arr)
+
+    quantized = tensor.convert_dtype(DType.I8)
+    assert np.isfinite(quantized.scale)
+
+    recon = quantized.convert_dtype(DType.F32).to_numpy()
+    assert np.all(np.isfinite(recon))
+
+
+def test_all_zero_tensor_quantization_roundtrips_exactly():
+    arr = np.zeros(32, dtype=np.float32)
+    tensor = UniversalTensor.from_numpy(arr)
+
+    quantized = tensor.convert_dtype(DType.I8)
+    recon = quantized.convert_dtype(DType.F32).to_numpy()
+
+    assert np.allclose(recon, 0.0)
+
+
+def test_i8_serialize_deserialize_matches_direct_dequantize():
+    arr = np.linspace(-8.0, 8.0, 512).astype(np.float32)
+    tensor = UniversalTensor.from_numpy(arr)
+    quantized = tensor.convert_dtype(DType.I8)
+
+    wire = quantized.serialize()
+    restored = UniversalTensor.deserialize(wire)
+
+    direct = quantized.convert_dtype(DType.F32).to_numpy()
+    via_wire = restored.convert_dtype(DType.F32).to_numpy()
+    assert np.array_equal(direct, via_wire)


### PR DESCRIPTION
## What's broken

`UniversalTensor.convert_dtype()` in `exo/interweave/tensor_format.py` packs quantized i8/i4 values as **unsigned** zero-point levels (0..255 for i8, 0..15 for the i4 nibbles), but `to_numpy()` unpacked them through a **signed** view (`np.int8` for i8, `nibble - 8` for i4). Any level >= 128 (i8) or >= 8 (i4) wraps negative on the way back out, and since `convert_dtype`'s dequantize branch reads its source through `self.to_numpy()`, every round trip that touches the upper half of the quantization range comes back corrupted.

Measured on a plain symmetric range:
```python
arr = np.linspace(-2.0, 2.0, 16).astype(np.float32)
q = UniversalTensor.from_numpy(arr).convert_dtype(DType.I8)
recon = q.convert_dtype(DType.F32).to_numpy()
# arr:   [-2.0 ... 2.0]
# recon: [-4.0, -3.73, -3.47, -3.47, -2.93, ... -0.27]  (max err 4.0 on a range of 4.0)
```
i4 is worse (max err ~2.27 on the same range). This is silent - no exception, no warning, just garbage data - which matters here since i8/i4 are exactly the dtypes `backend.py`/`llamacpp.py` declare for cross-backend tensor transfer in the distributed cluster (bandwidth/memory savings between CUDA/CPU/MLX nodes).

Root cause: `to_numpy()`'s generic dtype table (`DType.I8 -> np.int8`) is shared between "real" signed int8 tensors and the zero-point-quantized i8/i4 tensors produced by `convert_dtype`, but only the former is actually signed. Nothing in the repo tests this path - `exo/interweave/benchmark.py` exercises i8 conversion but only times it, never checks correctness - so it shipped silently.

## Second bug (found while fixing the first)

`convert_dtype` divides by `(max_val - min_val)` with no guard. A constant-valued block (e.g. a zero-padded KV-cache slot, or any tensor where every element is equal) has zero range, so `scale` becomes `0/0 = NaN`, poisoning the whole tensor:
```python
UniversalTensor.from_numpy(np.zeros(8, dtype=np.float32)).convert_dtype(DType.I8)
# RuntimeWarning: invalid value encountered in scalar divide -> NaN scale/zero_point
```

## Fix

- `to_numpy()`: for quantized i8 (`self.scale is not None`) read the buffer as `uint8`; for i4, unpack raw unsigned nibbles (0..15) instead of subtracting 8. Both now match exactly how `convert_dtype`'s quantizer packs them.
- `convert_dtype`: unified the i8/i4 quantize path to always produce unsigned zero-point levels (added the missing `.clip(0, 255)` for i8, which i4 already had), and guard the constant-block case with a safe unit scale instead of dividing by zero.

## Tests

Added `exo/interweave/test_tensor_format.py` (8 cases: i8/i4 round-trip precision bound, explicit high-level/high-nibble values that previously wrapped negative, random KV-cache-like data, constant-block NaN guard, all-zero exact round trip, serialize/deserialize consistency).

```
pytest exo/interweave/test_tensor_format.py    before: 7/8 fail (incl. a crash on the constant-block case)   after: 8/8 pass
```
Confirmed by reverting only `tensor_format.py` (`git stash` on that file) and re-running the new test file against the unmodified original.

Also ran the existing suite (`test_interweave.py`, `test_distributed.py`, `test_large_memory.py`) before/after - identical results (the one `test_router` failure is pre-existing, `pytest-asyncio` isn't installed in this environment, unrelated to this change).

Ran `ruff check` on both touched files - no new lint issues introduced (12 pre-existing warnings in `tensor_format.py`, none in the new test file).

## Honestly not covered

Didn't touch `benchmark.py` itself (still only measures timing, not correctness) or the CUDA/MLX/torch conversion paths (`to_tinygrad`/`to_mlx`/`to_torch`) - no GPU available here, and those don't go through the i8/i4 packing logic anyway. `zero_point`'s `int32` wire format (`struct.pack('<i', ...)`) is unaffected by this fix since the new zero_point values stay in the same small range as before.
